### PR TITLE
Added $= as alias for infix and updated version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See [www.destructuring-bind.org/infix](http://www.destructuring-bind.org/infix/)
 ; => 64
 ```
 
-You can also use `$=` as a short alias for `infix`, like this, for example:
+You can also use `$=` as a short alias for `infix`, like this for example:
 ```clojure
 (refer 'infix.macros :only '[$=])
 ; => nil

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There is a version hosted at [Clojars](https://clojars.org/rm-hull/infix).
 For leiningen include a dependency:
 
 ```clojure
-[rm-hull/infix "0.2.11"]
+[rm-hull/infix "0.2.12"]
 ```
 
 For maven-based projects, add the following to your `pom.xml`:
@@ -63,6 +63,17 @@ See [www.destructuring-bind.org/infix](http://www.destructuring-bind.org/infix/)
 (infix (3 + 5) * 8)
 ; => 64
 ```
+
+You can also use `$=` as a short alias for `infix` like this, for example:
+```clojure
+(refer 'infix.macros :only '[$=])
+; => nil
+
+($= 3 + 5 * 8)
+; => 43
+```
+
+All of the examples below should work if you replace `infix` by `$=`.
 
 Some `Math` functions have been aliased (see [below](#aliased-operators--functions)
 for full list), so nullary and unary-argument functions can be used as follows:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For maven-based projects, add the following to your `pom.xml`:
 <dependency>
   <groupId>rm-hull</groupId>
   <artifactId>infix</artifactId>
-  <version>0.2.11</version>
+  <version>0.2.12</version>
 </dependency>
 ```
 
@@ -64,7 +64,7 @@ See [www.destructuring-bind.org/infix](http://www.destructuring-bind.org/infix/)
 ; => 64
 ```
 
-You can also use `$=` as a short alias for `infix` like this, for example:
+You can also use `$=` as a short alias for `infix`, like this, for example:
 ```clojure
 (refer 'infix.macros :only '[$=])
 ; => nil

--- a/src/infix/macros.clj
+++ b/src/infix/macros.clj
@@ -36,6 +36,13 @@
    (map resolve-alias)
    rewrite))
 
+;; Short alias for infix
+(defmacro $=
+  "Takes an infix expression, resolves an aliases before rewriting the
+   infix expressions into standard LISP prefix expressions."
+  [& expr]
+  `(infix ~@expr))
+
 (defn- binding-vars [bindings]
   (->>
    bindings

--- a/test/infix/macros_tests.clj
+++ b/test/infix/macros_tests.clj
@@ -23,7 +23,7 @@
 (ns infix.macros-tests
   (:require
    [clojure.test :refer :all]
-   [infix.macros :refer [infix from-string]]))
+   [infix.macros :refer [infix $= from-string]]))
 
 (def ε 0.0000001)
 
@@ -38,7 +38,24 @@
   (is (= 1 (infix 1 - 1 + 1)))
   (is (= 2 (infix 1 - 2 + 3))))
 
+(deftest basic-arithmetic-$=
+  (is (= (+ 3 4) ($= 3 + 4)))
+  (is (= 43 ($= 3 + 5 * 8)))
+  (is (= 64 ($= (3 + 5) * 8)))
+  (is (= 0 ($= (3 - 2) - 1)))
+  (is (= 0 ($= 3 - 2 - 1)))
+  (is (= 5 ($= 3 + 2 % 3)))
+  (is (= 2 ($= (3 + 2) % 3)))
+  (is (= 1 ($= 1 - 1 + 1)))
+  (is (= 2 ($= 1 - 2 + 3))))
+
 (deftest check-aliasing
+  (is (= 5.0 (infix √ (5 * 5))))
+  (is (= 2 (infix 5 % 3)))
+  (let [t 0.324]
+    (is (> ε (Math/abs (- (infix sin (2 * t) + 3 * cos (4 * t)) 1.4176457261295824))))))
+
+(deftest check-aliasing-$=
   (is (= 5.0 (infix √ (5 * 5))))
   (is (= 2 (infix 5 % 3)))
   (let [t 0.324]


### PR DESCRIPTION
This adds `$=` as an alias for `infix`.   The `$=` macro simply calls `infix`, passing all arguments in the original order, so `$=`'s behavior should be identical to `infix`'s.  The name `$=` comes from [Incanter's similar macro](https://data-sorcery.org/2010/05/14/infix-math).

I wasn't sure how much to add to macros_tests.clj.  I duplicated the first two `deftests`.  It doesn't seem worthwhile to copy all of the `deftests` given how simple the definition of `$=` is.

I also changed the project.clj and Maven version references from 0.2.11 to 0.2.12.  I'm pretty sure it's just an oversight that these haven't been changed to match the current version.