### PR TITLE
Fix issue with parsing envrefs that contain _ at the beginning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject rm-hull/infix "0.4.1"
+(defproject rm-hull/infix "0.4.2"
   :description "A small Clojure library for expressing LISP expressions as infix rather than prefix notation"
   :url "https://github.com/rm-hull/infix"
   :license {

--- a/src/infix/grammar.clj
+++ b/src/infix/grammar.clj
@@ -65,7 +65,7 @@
 
 (def envref
   (m/do*
-   (fst <- letter)
+   (fst <- (any-of letter (match "_")))
    (rst <- (token (many alpha-num)))
    (m/return (let [kw (keyword (strip-location (cons fst rst)))]
                (fn [env]

--- a/test/infix/macros_tests.clj
+++ b/test/infix/macros_tests.clj
@@ -89,6 +89,7 @@
   (is (= 1 ((from-string "1 - 1 + 1"))))
   (is (= 2 ((from-string "1 - 2 + 3"))))
   (is (= 7 ((from-string [x] "x + 3") 4)))
+  (is (= 7 ((from-string [_x] "_x + 3") 4)))
   (is (= 1 ((from-string [x] {:+ -} "x + 3") 4)))
   (is (= 7 ((from-string [] {:x 6 :+ +} "x + 1"))))
   (is (= 28.0 ((from-string [] "3 + 5**2"))))


### PR DESCRIPTION
This change fixes errors when trying to use environment variables (envrefs) which look like `_var1`.
So, allowing first character to be '_' in those names.