### PR TITLE
Make exponentiaion right-associative

### DIFF
--- a/src/infix/core.clj
+++ b/src/infix/core.clj
@@ -94,6 +94,9 @@
    'Math/sqrt 'Math/exp  'Math/log
    'Math/abs  'Math/signum])
 
+(def right-associative-operators
+  #{'Math/pow})
+
 (defn- bounded? [sym]
   (if-let [v (resolve sym)]
     (bound? v)
@@ -128,7 +131,9 @@
     (let [infix-expr (map resolve-alias infix-expr)]
       (loop [ops operator-precedence]
         (if-let [op (first ops)]
-          (let [idx (.lastIndexOf ^java.util.List infix-expr op)]
+          (let [idx (if (right-associative-operators op)
+                      (.indexOf ^java.util.List infix-expr op)
+                      (.lastIndexOf ^java.util.List infix-expr op))]
             (if (pos? idx)
               (let [[expr1 [op & expr2]] (split-at idx infix-expr)]
                 (list op (rewrite expr1) (rewrite expr2)))

--- a/test/infix/grammar_test.clj
+++ b/test/infix/grammar_test.clj
@@ -116,6 +116,7 @@
     (is (thrown? IllegalStateException ((parse-all expression "3 + 4") {})))
     (is (= 43 ((parse-all expression "3 + 5 * 8") env)))
     (is (= 64 ((parse-all expression "(3 + 5) * 8") env)))
+    (is (= 65536.0 ((parse-all expression "2 ** 2 ** 2 ** 2") env)))
     (is (= 10 ((parse-all expression "x_y_z * 2 + _a") env)))
     (is (= 8 ((parse-all expression "x_y_z * 2 + _a / _a.b") env)))))
 

--- a/test/infix/macros_tests.clj
+++ b/test/infix/macros_tests.clj
@@ -80,7 +80,8 @@
 (deftest check-binary-precedence
   (let [x 4 y 3]
     (is (= 12   (infix x . y)))
-    (is (= 64.0 (infix x ** y)))))
+    (is (= 64.0 (infix x ** y)))
+    (is (= 65536.0 (infix 2 ** 2 ** 2 ** 2)))))
 
 (deftest check-from-string
   (is (= 5 ((from-string "5"))))
@@ -98,6 +99,7 @@
   (is (= 380175 ((from-string [t] "( t * (  t  >> 5 | t >>  8 ) ) >> ( t >> 16  )") 3425)))
   (is (= 0 ((from-string "(3-2)-1"))))
   (is (= 0 ((from-string "3 - 2 - 1"))))
+  (is (= 65536.0 ((from-string "2 ** 2 ** 2 ** 2"))))
   (is (= Double/POSITIVE_INFINITY ((from-string "divide(3, 0)"))))
   (is (= Double/NEGATIVE_INFINITY ((from-string "-3 ÷ 0"))))
   (is (= 5 ((from-string [t] "t - 2") 7)))


### PR DESCRIPTION
I noticed that exponentiation is left-associative in the current implementation (as are all operators), but it's generally accepted to be right-associative. 

`2 ** 2 ** 2 ** 2` should evaluate as `2 ** (2 ** (2 ** 2)) = 65536`, not `(((2 ** 2) ** 2) ** 2) = 256`.

This PR changes it to be right-associative, and adds some tests to check that it's working.
Fixes #29.